### PR TITLE
Add handler for non-existent user.

### DIFF
--- a/includes/Shortcodes/User.php
+++ b/includes/Shortcodes/User.php
@@ -23,7 +23,11 @@ final class KBJ_UserShortcodesPlus_Shortcodes_User
         $property = $this->get_property( $tag );
         $userdata = $this->get_userdata( $atts[ 'id' ] );
 
-        return $userdata->$property;
+        if( ! $userdata && defined( 'WP_DEBUG' ) && WP_DEBUG ){
+            return '<p>' . sprintf( __( 'User ID %s does not exist.', 'user-shortcodes-plus' ), $atts[ 'id' ] ) . '</p>';
+        }
+
+        return ( is_object( $userdata ) ) ? $userdata->$property : '';
     }
 
     private function get_property( $tag )


### PR DESCRIPTION
Closes #4.

If the passed user `id` does not represent an existing user, ie `get_userdata()` returns false, return an empty string.

If `WP_DEBUG` is enabled, return a custom error message.